### PR TITLE
Let the AccountIdFactory work for the initial ID.

### DIFF
--- a/NET.S.2019.Sakovich.15/MonkeyBanker/MonkeyBanker.ServiceResolver/ServiceResolver.cs
+++ b/NET.S.2019.Sakovich.15/MonkeyBanker/MonkeyBanker.ServiceResolver/ServiceResolver.cs
@@ -47,7 +47,7 @@ namespace MonkeyBanker.ServiceResolver
 
             kernel.Bind<IIdFactory<Account>>().To<IncrementAccountIdFactory>()
                 .InSingletonScope()
-                .WithConstructorArgument(typeof(IEnumerable<int>), (context) => kernel.Get<MonkeyBankerContext>().Accounts.Select(acc => acc.ID));
+                .WithConstructorArgument(typeof(IEnumerable<int>), (context) => kernel.Get<MonkeyBankerContext>().Accounts.Select(acc => acc.ID).DefaultIfEmpty());
 
             return kernel;
         }

--- a/NET.S.2019.Sakovich.15/MonkeyBanker/MonkeyBanker.Services.IdFactories/IncrementAccountIdFactory.cs
+++ b/NET.S.2019.Sakovich.15/MonkeyBanker/MonkeyBanker.Services.IdFactories/IncrementAccountIdFactory.cs
@@ -14,12 +14,12 @@ namespace MonkeyBanker.Services.IdFactories
 
         public IncrementAccountIdFactory(IEnumerable<int> ids)
         {
-            this.ids = ids ?? Enumerable.Empty<int>();
+            this.ids = ids.DefaultIfEmpty(default);
         }
 
         public void GenerateId(Account acc)
         {
-            acc.ID = this.ids.Any() ? this.ids.Max() + 1 : default;
+            acc.ID = this.ids.Max() + 1;
         }
     }
 }

--- a/NET.S.2019.Sakovich.15/MonkeyBanker/MonkeyBanker.Services.IdFactories/IncrementAccountIdFactory.cs
+++ b/NET.S.2019.Sakovich.15/MonkeyBanker/MonkeyBanker.Services.IdFactories/IncrementAccountIdFactory.cs
@@ -14,12 +14,12 @@ namespace MonkeyBanker.Services.IdFactories
 
         public IncrementAccountIdFactory(IEnumerable<int> ids)
         {
-            this.ids = ids;
+            this.ids = ids ?? Enumerable.Empty<int>();
         }
 
         public void GenerateId(Account acc)
         {
-            acc.ID = this.ids.Max() + 1;
+            acc.ID = this.ids.Any() ? this.ids.Max() + 1 : default;
         }
     }
 }

--- a/NET.S.2019.Sakovich.15/MonkeyBanker/MonkeyBanker.Services.IdFactories/IncrementAccountIdFactory.cs
+++ b/NET.S.2019.Sakovich.15/MonkeyBanker/MonkeyBanker.Services.IdFactories/IncrementAccountIdFactory.cs
@@ -14,7 +14,12 @@ namespace MonkeyBanker.Services.IdFactories
 
         public IncrementAccountIdFactory(IEnumerable<int> ids)
         {
-            this.ids = ids.DefaultIfEmpty(default);
+            if (ids is null)
+            {
+                throw new ArgumentNullException($"{nameof(ids)} is null.");
+            }
+
+            this.ids = ids.Any() ? ids : throw new ArgumentException($"{nameof(ids)} is empty.");
         }
 
         public void GenerateId(Account acc)


### PR DESCRIPTION
If we do not have IDs yet, we need to generate the first one instead of throwing unhandled LINQ exception.